### PR TITLE
changed order of readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,17 +4,17 @@ OpenHire
 
 2. Download and open up Ganache (https://www.trufflesuite.com/ganache)
 
-3. Compile contracts using command "truffle compile" (If you do not have truffle installed globally
+3. Create a .secret file in your root directory.
+
+4. In Ganache, create a new workspace, and in the server section, change the port number to 8545 and save.
+
+5. Copy and paste the 12 word mnemonic from Ganache into the .secret file
+
+6. Compile contracts using command "truffle compile" (If you do not have truffle installed globally
    use "./node_modules/.bin/truffle compile")
 
-4. Migrate using command "truffle migrate" (If you do not have truffle installed globally
+7. Migrate using command "truffle migrate" (If you do not have truffle installed globally
    use "./node_modules/.bin/truffle migrate")
-
-5. Create a .secret file in your root directory.
-
-6. In Ganache, create a new workspace, and in the server section, change the port number to 8545 and save.
-
-7. Copy and paste the 12 word mnemonic from Ganache into the .secret file
 
 8. Download Metamask extension for your browser and log in to Metamask using the Ganache seed account
    (12 word mnemonic from step 6)


### PR DESCRIPTION
Order of the readme doesn't work. You need a .secret file first along with 12 word mnemonic to compile contracts.
Rearranged to have those steps first.